### PR TITLE
on-load should be a no-op on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Pass a dom `node` to `onload` to have a `onloadFn` function fire when the dom `n
 [npm-url]: https://npmjs.org/package/on-load
 [travis-image]: https://img.shields.io/travis/shama/on-load/master.svg?style=flat-square
 [travis-url]: https://travis-ci.org/shama/on-load
-[downloads-image]: http://img.shields.io/npm/dm/vel.svg?style=flat-square
+[downloads-image]: http://img.shields.io/npm/dm/on-load.svg?style=flat-square
 [downloads-url]: https://npmjs.org/package/on-load
 [standard-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square
 [standard-url]: https://github.com/feross/standard

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ document.body.appendChild(div)
 document.body.removeChild(div)
 ```
 
+## API
+
+### `onload(node, onloadFn, onunloadFn, [caller])`
+
+Pass a dom `node` to `onload` to have a `onloadFn` function fire when the dom `node` is added to the document `dom` and a `onunloadFn` fire when the dom `node` is removed from the document `dom`.  Optionally a `caller` ID can be set to associate the onload/onunload hooks with a particular instance of of a dom `node`.  This is commonly used when 'componentizing' dom nodes.
+
 # license
 (c) 2016 Kyle Robinson Young. MIT License
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,16 @@ if (window && window.MutationObserver) {
       eachMutation(mutations[i].addedNodes, turnon)
     }
   })
+  if (document.body) {
+    beginObserve(observer)
+  } else {
+    document.addEventListener('DOMContentLoaded', function (event) {
+      beginObserve(observer)
+    })
+  }
+}
+
+function beginObserve (observer) {
   observer.observe(document.body, {
     childList: true,
     subtree: true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "on-load",
   "version": "3.2.1",
   "description": "On load/unload events for DOM elements using a MutationObserver",
-  "main": "index.js",
+  "main": "server.js",
+  "browser": "index.js",
   "scripts": {
     "start": "wzrd test.js:bundle.js",
     "test": "standard && browserify test.js | testron"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "on-load",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "On load/unload events for DOM elements using a MutationObserver",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,1 @@
+module.exports = function () {}


### PR DESCRIPTION
in node, on-load shouldn't attempt to do anything since with later versions of
bel (which use pelo), the returned result is a string and not a "DOM" object
like in bel < 5.